### PR TITLE
drop clang-18-dev package

### DIFF
--- a/clang-18.yaml
+++ b/clang-18.yaml
@@ -10,10 +10,11 @@ package:
     memory: 64Gi
   dependencies:
     runtime:
-      - clang-18-dev
       - gcc
       - glibc-dev
       - libLLVM-18
+      - libLLVM-18
+      - libclang-cpp-18
       - llvm-18
 
 environment:
@@ -117,15 +118,6 @@ pipeline:
   - uses: strip
 
 subpackages:
-  - name: "clang-18-dev"
-    description: "headers for clang-18"
-    pipeline:
-      - uses: split/dev
-    dependencies:
-      runtime:
-        - libLLVM-18
-        - libclang-cpp-18
-
   - name: "libclang-cpp-18"
     description: "Clang 18 runtime library"
     pipeline:


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
